### PR TITLE
Implement support for multi-site data

### DIFF
--- a/src/base/WidgetData.php
+++ b/src/base/WidgetData.php
@@ -1,6 +1,7 @@
 <?php
 namespace verbb\metrix\base;
 
+use craft\helpers\Cp;
 use verbb\metrix\Metrix;
 
 use Craft;
@@ -72,6 +73,10 @@ class WidgetData extends Model implements WidgetDataInterface
             $this->dimension,
             $this->period,
         ];
+
+        if ($this->widget?->getView()?->supportsMultiSite) {
+            $cacheKey[] = Cp::requestedSite()->id;
+        }
         
         return implode('.', $cacheKey);
     }

--- a/src/controllers/DashboardController.php
+++ b/src/controllers/DashboardController.php
@@ -151,8 +151,13 @@ class DashboardController extends Controller
         $this->requireAcceptsJson();
 
         $id = $this->request->getParam('id');
-
         $widget = Metrix::$plugin->getWidgets()->getWidgetById($id);
+
+        $viewHandle = $this->request->getParam('view');
+        $view = Metrix::$plugin->getViews()->getViewByHandle($viewHandle);
+        if ($view && $view->supportsMultiSite) {
+            $site = $this->request->getParam('site');
+        }
 
         return $this->asJson($widget->getWidgetData());
     }

--- a/src/controllers/ViewsController.php
+++ b/src/controllers/ViewsController.php
@@ -61,6 +61,7 @@ class ViewsController extends Controller
         $view->id = $this->request->getParam('id');
         $view->name = $this->request->getParam('name');
         $view->handle = $this->request->getParam('handle');
+        $view->supportsMultiSite = $this->request->getParam('supportsMultiSite');
 
         if (!Metrix::$plugin->getViews()->saveView($view)) {
             return $this->asModelFailure($view, modelName: 'view');

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -78,6 +78,7 @@ class Install extends Migration
             'id' => $this->primaryKey(),
             'name' => $this->string()->notNull(),
             'handle' => $this->string()->notNull(),
+            'supportsMultiSite' => $this->boolean()->defaultValue(false),
             'settings' => $this->text(),
             'sortOrder' => $this->smallInteger()->unsigned(),
             'dateCreated' => $this->dateTime()->notNull(),

--- a/src/migrations/m260512_191215_add_multisite_column_to_views.php
+++ b/src/migrations/m260512_191215_add_multisite_column_to_views.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace verbb\metrix\migrations;
+
+use Craft;
+use craft\db\Migration;
+
+/**
+ * m260512_191215_add_multisite_column_to_views migration.
+ */
+class m260512_191215_add_multisite_column_to_views extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->addColumn('{{%metrix_views}}', 'supportsMultiSite', $this->boolean()->defaultValue(false));
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        $this->dropColumn('{{%metrix_views}}', 'supportsMultiSite');
+
+        return false;
+    }
+}

--- a/src/migrations/m260512_191215_add_multisite_column_to_views.php
+++ b/src/migrations/m260512_191215_add_multisite_column_to_views.php
@@ -15,7 +15,10 @@ class m260512_191215_add_multisite_column_to_views extends Migration
      */
     public function safeUp(): bool
     {
-        $this->addColumn('{{%metrix_views}}', 'supportsMultiSite', $this->boolean()->defaultValue(false));
+        $table = Craft::$app->db->schema->getTableSchema('metrix_views');
+        if (!isset($table->columns['supportsMultisite'])) {
+            $this->addColumn('{{%metrix_views}}', 'supportsMultiSite', $this->boolean()->defaultValue(false));
+        }
 
         return true;
     }

--- a/src/models/View.php
+++ b/src/models/View.php
@@ -18,4 +18,5 @@ class View extends Model
     public ?DateTime $dateUpdated = null;
     public ?string $uid = null;
 
+    public ?bool $supportsMultiSite = false;
 }

--- a/src/services/Views.php
+++ b/src/services/Views.php
@@ -93,6 +93,7 @@ class Views extends Component
         $viewRecord = $this->_getViewRecordById($view->id);
         $viewRecord->name = $view->name;
         $viewRecord->handle = $view->handle;
+        $viewRecord->supportsMultiSite = $view->supportsMultiSite;
 
         if ($isNewView) {
             $maxSortOrder = (new Query())
@@ -201,6 +202,7 @@ class Views extends Component
                 'id',
                 'name',
                 'handle',
+                'supportsMultiSite',
                 'sortOrder',
                 'dateCreated',
                 'dateUpdated',

--- a/src/sources/GoogleAnalytics.php
+++ b/src/sources/GoogleAnalytics.php
@@ -1,6 +1,7 @@
 <?php
 namespace verbb\metrix\sources;
 
+use craft\helpers\Cp;
 use verbb\metrix\Metrix;
 use verbb\metrix\base\OAuthSource;
 use verbb\metrix\base\Period;
@@ -212,6 +213,25 @@ class GoogleAnalytics extends OAuthSource
             $payload['dimensions'] = [['name' => $widgetData->dimension]];
         } else {
             $payload['dimensions'] = [['name' => $intervalDimension]];
+        }
+
+        if ($widgetData->widget?->getView()?->supportsMultiSite) {
+            $pBaseUrl = Craft::$app->getSites()->primarySite->baseUrl;
+
+            $url = str_replace($pBaseUrl, '', Cp::requestedSite()->baseUrl);
+            if ($url[0] !== "/") {
+                $url = "/$url";
+            }
+
+            $payload['dimensionFilter'] = [
+                'filter' => [
+                    'fieldName' => 'pagePath',
+                    'stringFilter' => [
+                        'matchType' => 'BEGINS_WITH',
+                        'value' => $url
+                    ]
+                ]
+            ];
         }
 
         $response = $this->request('POST', 'https://analyticsdata.googleapis.com/v1beta/' . $this->getPropertyId() . ':runReport', [

--- a/src/sources/GoogleAnalytics.php
+++ b/src/sources/GoogleAnalytics.php
@@ -219,9 +219,11 @@ class GoogleAnalytics extends OAuthSource
             $pBaseUrl = Craft::$app->getSites()->primarySite->baseUrl;
 
             $url = str_replace($pBaseUrl, '', Cp::requestedSite()->baseUrl);
-            if ($url[0] !== "/") {
+            if (isset($url[0]) && $url[0] !== "/") {
                 $url = "/$url";
             }
+
+            if ($url === '') $url = '/';
 
             $payload['dimensionFilter'] = [
                 'filter' => [

--- a/src/templates/dashboard/index.html
+++ b/src/templates/dashboard/index.html
@@ -5,6 +5,23 @@
     { label: 'Dashboard' | t('metrix'), url: url('metrix') }
 ] %}
 
+{% set sites = siteMenuItems(null, requestedSite) %}
+{% js %}
+window.Craft.sites = JSON.parse(`{{ sites|json_encode|raw }}`);
+{% endjs %}
+
+{% if craft.app.getIsMultiSite() and requestedSite %}
+    {% set crumbs = crumbs | unshift({
+        id: 'site-crumb',
+        icon: 'world',
+        label: requestedSite.name | t('site'),
+        menu: {
+            items: siteMenuItems(null, requestedSite),
+            label: 'Select site' | t('site')
+        },
+    }) %}
+{% endif %}
+
 {% set title = 'Dashboard' | t('metrix') %}
 {% set selectedSubnavItem = 'dashboard' %}
 {% set showHeader = false %}

--- a/src/templates/views/_edit.html
+++ b/src/templates/views/_edit.html
@@ -62,6 +62,14 @@
     required: true,
 }) }}
 
+{{ forms.checkbox({
+    label: 'Supports multi-site data' | t('metrix'),
+    instructions: 'If this view will be retrieving site-specific data' | t('metrix'),
+    id: 'supportsMultiSite',
+    name: 'supportsMultiSite',
+    checked: (viewModel is defined ? viewModel.supportsMultiSite|string : null),
+    errors: (viewModel is defined ? viewModel.getErrors('supportsMultiSite') : null),
+}) }}
 
 {% endblock %}
 


### PR DESCRIPTION
This PR implements very basic support for configuring a View to support retrieving data from multiple sites.

Currently this **only supports environments where the root URL of all Craft sites is the same.** (think of `$PRIMARY_SITE_URL/site1`, `$PRIMARY_SITE_URL/site2`, etc)
This because a Source can only be configured with one property/app, which are (typically) only for one single domain.

However, support for differing root domains can be added by adjusting the payload I added (and making whatever other necessary changes within Metrix):
```json
"dimensionFilter": {
  "filter": {
    "fieldName": "pageLocation",
    "stringFilter": {
      "matchType": "BEGINS_WITH",
      "value": "https://example.com/"
    }
  }
}
```

There's no need to merge this PR as-is, or at all, at the very least this is a reference implementation for something that could be. For now, I will likely be running a fork of Metrix for a client that requested this functionality.